### PR TITLE
Install before build.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,9 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v2
     - name: Build Source Code
-      run: npm run build
+      run: |
+        npm ci
+        npm run build
     - name: Publish (If Updated Version)
       uses: pascalgn/npm-publish-action@1.3.8
       with:


### PR DESCRIPTION
Node types still aren't available, assuming due to lack of installation.